### PR TITLE
Restore layout while retaining style isolation

### DIFF
--- a/css/materiadark.scss
+++ b/css/materiadark.scss
@@ -19,3 +19,7 @@
 .layout-border {
   background-color: #303030;
 }
+
+.grid-bg {
+  background-color: #303030;
+}

--- a/css/materialight.scss
+++ b/css/materialight.scss
@@ -17,10 +17,9 @@ $footer-bg: #4266A1;
 }
 
 .layout-border {
-  background-color:  #f0f0f0;
   padding: 20px;
 }
 
-.layout-border {
-  background-color: #f0f0f0;
+.grid-bg {
+  background-color:  #f0f0f0;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -27,7 +27,7 @@
 .cell-title {
   font-size: 1.2em;
   font-weight: bold;
-  margin: 15px 0 5px 0;
+  margin: 15px 0 0 0;
   display: block;
   text-align: center;
 }
@@ -49,6 +49,9 @@
   box-shadow: 0 0 5px 2px rgba(0, 123, 255, 0.7); /* glowing blue outline */
   transform: scale(1.1);      /* slightly enlarge on hover */
   border: 2px solid #bed4ec;  /* blue border */
+  cursor: pointer; /* Changes the cursor to a pointer when hovered */
+  transform: scale(1.1); /* Enlarges the image when hovered */
+  transition: transform 0.2s; /* Smooth transition effect */
 }
 /* for news page */
 .listing img {
@@ -58,10 +61,14 @@
   display: block;
 }
 
-h3 {
+h1, h3, .title, .centered {
   text-align: center;
 }
 
 .title {
   text-align: center;
+}
+
+.grid-bg {
+  padding: 4px;
 }

--- a/index.qmd
+++ b/index.qmd
@@ -7,8 +7,9 @@ css: css/styles.css
 bibliography: resources/references.bib
 ---
 
-# Welcome to the Health Data Science Sandbox {.centered}
+# Welcome to the Health Data Science Sandbox
 
+::: {.grid-bg}
 ### Access our training modules
 
 ::: {.layout-border}
@@ -66,15 +67,20 @@ bibliography: resources/references.bib
 
 :::
 :::
+:::
 
 
 ### We are a collaborative project with team members spanning five Danish universities
 
-The Health Data Science Sandbox is a national project coordinated by the [Center for Health Data Science](https://heads.ku.dk/) at the University of Copenhagen. We're working with a network of health data science experts to build training resources on academic supercomputers for students and researchers in Denmark. Our Sandbox contains [training modules](modules/index.qmd) that pair topical datasets with recommended analysis tools, pipelines, and learning materials/tutorials in a portable, containerized format.
+The Health Data Science Sandbox is a national project coordinated by the [Center for Health Data Science](https://heads.ku.dk/) at the University of Copenhagen.
+We're working with a network of health data science experts to build training resources on academic supercomputers for students and researchers in Denmark.
+Our Sandbox contains [training modules](modules/index.qmd) that pair topical datasets with recommended analysis tools, pipelines, and learning materials/tutorials in a portable, containerized format.
 
 ![](images/Sandbox_workflow_ai_horizontal2w-01.png){fig-align="center"}
 
 ### To get involved as a trainee, researcher, or educator in Denmark:
+
+::: {.centered}
 
 **TRAINEES**: [join](news.qmd) our next scheduled workshop or a supported university course
 
@@ -84,20 +90,13 @@ The Health Data Science Sandbox is a national project coordinated by the [Center
 
 **EDUCATORS**: [host](access/index.qmd) a training event or course in the Sandbox with our support
 
-
-&nbsp;
+:::
 
 :::{.callout-note title="A note on Sandbox data policy"}
-The Sandbox aims to be a resource for learning new analysis approaches and tools for health data science on useful, interesting, and safe-to-share datasets. All person-specific datasets in the Sandbox are non-sensitive and GDPR-safe because they are 1) sourced from public databases, 2) fully anonymous/non-sensitive from a GDPR perspective, and/or 3) synthetic. To learn more, check out [Datasets](https://hds-sandbox.github.io/datasets/datapolicy.html) where we explain our data policy in detail and our approach to synthetic data generation.
+The Sandbox aims to be a resource for learning new analysis approaches and tools for health data science on useful, interesting, and safe-to-share datasets.
+All person-specific datasets in the Sandbox are non-sensitive and GDPR-safe because they are
+1) sourced from public databases, 2) fully anonymous/non-sensitive from a GDPR perspective, and/or 3) synthetic.
+To learn more, check out [Datasets](https://hds-sandbox.github.io/datasets/datapolicy.html) where we explain our data policy in detail and our approach to synthetic data generation.
 :::
 
 **Thanks to the Novo Nordisk Foundation for funding the National Health Data Science Project! Please give credit if you use our open-source materials in any form (NNF grant number NNF20OC0063268).**
-
-<style>
-/* Targeting images with the class "hover-target" when hovered */
-img.hover-target:hover {
-    cursor: pointer; /* Changes the cursor to a pointer when hovered */
-    transform: scale(1.1); /* Enlarges the image when hovered */
-    transition: transform 0.2s; /* Smooth transition effect */
-}
-</style>


### PR DESCRIPTION
This fixes some unintentional layout changes from #32 while retaining (and improving) the division between styles and content.